### PR TITLE
Fix Formatting Issues with Skills Section

### DIFF
--- a/awesome-cv.cls
+++ b/awesome-cv.cls
@@ -426,9 +426,9 @@
 %                Commands for utilities
 %-------------------------------------------------------------------------------
 % Use to align an element of tabular table
-\newcolumntype{L}[1]{>{\raggedright\let\newline\\\arraybackslash\hspace{0pt}}m{#1}}
-\newcolumntype{C}[1]{>{\centering\let\newline\\\arraybackslash\hspace{0pt}}m{#1}}
-\newcolumntype{R}[1]{>{\raggedleft\let\newline\\\arraybackslash\hspace{0pt}}m{#1}}
+\newcolumntype{L}[1]{>{\raggedright\let\newline\\\arraybackslash\hspace{0pt}}p{#1}}
+\newcolumntype{C}[1]{>{\centering\let\newline\\\arraybackslash\hspace{0pt}}p{#1}}
+\newcolumntype{R}[1]{>{\raggedleft\let\newline\\\arraybackslash\hspace{0pt}}p{#1}}
 
 % Use to draw horizontal line with specific thickness
 \def\vhrulefill#1{\leavevmode\leaders\hrule\@height#1\hfill \kern\z@}

--- a/awesome-cv.cls
+++ b/awesome-cv.cls
@@ -725,7 +725,7 @@
   \begin{center}
     \setlength\tabcolsep{1ex}
     \setlength{\extrarowheight}{0pt}
-    \begin{tabular*}{\textwidth}{@{\extracolsep{\fill}} r L{\textwidth * \real{0.9}}}
+    \begin{tabular*}{\textwidth}{@{\extracolsep{\fill}} R{2.15cm} L{\textwidth - 2.5cm}}
 }{%
     \end{tabular*}
   \end{center}


### PR DESCRIPTION
Fixes the following issues with cvskills:

1. Text overflows to the margins
    1.1 Fixed by defining the width of columns in cvskills environment
2. Formatting issue when cvskills span multiple lines
    2.1 Changed the column formatting from vertically center aligned to vertically top aligned
    2.2 This change does not impact formatting of any other part of the CV